### PR TITLE
Fix parsing of filesystem URIs on Windows

### DIFF
--- a/src/Testing/BaseTestCase.php
+++ b/src/Testing/BaseTestCase.php
@@ -148,6 +148,22 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Returns URI to local file system.
+     *
+     * @param  string $path
+     *
+     * @return string
+     */
+    protected function getLocalUri($path)
+    {
+        if (preg_match('/^[A-Z]:/', $path)) {
+            $path = '/' . strtr($path, '\\', '/');
+        }
+
+        return 'file://' . $path;
+    }
+
+    /**
      * @codeCoverageIgnore (cannot cover code whose behaviour depends on PHP version)
      *
      * @param mixed $variable

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -200,6 +200,10 @@ class Uri
             }
         }
 
+        if ($this->parts['scheme'] === 'file' && preg_match('/^[A-Z]:/', $this->parts['path'])) {
+            $this->parts['path'] = '/' . $this->parts['path'];
+        }
+
         $this->authority = $this->buildAuthority();
         $this->segments = $this->buildSegments();
         $this->primaryIdentifier = $this->buildPrimaryIdentifier();

--- a/tests/Draft/Draft4Test.php
+++ b/tests/Draft/Draft4Test.php
@@ -31,9 +31,9 @@ class Draft4Test extends BaseTestCase
     ) {
         $remoteDir = realpath(__DIR__.'/../../vendor/json-schema/test-suite/remotes');
         $validator = Validator::buildDefault(function ($uri) use ($remoteDir) {
-            return str_replace('http://localhost:1234', 'file://'.$remoteDir, $uri);
+            return str_replace('http://localhost:1234', $this->getLocalUri($remoteDir), $uri);
         });
-        $actualErrors = $validator->validate($instance, $schema, 'file://'.$file);
+        $actualErrors = $validator->validate($instance, $schema, $this->getLocalUri($file));
 
         $this->assertValidationResult(
             $file,

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -204,7 +204,7 @@ class ResolverTest extends BaseTestCase
         $this->resolver->setBaseSchema(new stdClass(), new Uri('file:///foo/bar'));
         $schemaFile = __DIR__.'/Data/schemas/invalid/undecodable.json';
         $reference = new stdClass();
-        $reference->{'$ref'} = "file://{$schemaFile}";
+        $reference->{'$ref'} = $this->getLocalUri($schemaFile);
         $this->resolver->resolve($reference);
     }
 
@@ -216,7 +216,7 @@ class ResolverTest extends BaseTestCase
         $this->resolver->setBaseSchema(new stdClass(), new Uri('file:///foo/bar'));
         $schemaFile = __DIR__.'/Data/schemas/invalid/not-an-object.json';
         $reference = new stdClass();
-        $reference->{'$ref'} = "file://{$schemaFile}";
+        $reference->{'$ref'} = $this->getLocalUri($schemaFile);
         $this->resolver->resolve($reference);
     }
 
@@ -330,7 +330,7 @@ class ResolverTest extends BaseTestCase
 
         return [
             ['http://json-schema.org/draft-03/schema#', $schema3],
-            ["file://{$schemaFile}", $schema3],
+            [$this->getLocalUri($schemaFile), $schema3],
         ];
     }
 

--- a/tests/WalkerTest.php
+++ b/tests/WalkerTest.php
@@ -25,7 +25,7 @@ class WalkerTest extends BaseTestCase
         $resolver->setPreFetchHook(function ($uri) {
             return str_replace(
                 'http://localhost:1234',
-                'file://'.__DIR__.'/Data/schemas',
+                $this->getLocalUri(__DIR__.'/Data/schemas'),
                 $uri
             );
         });


### PR DESCRIPTION
Converts `file://C:\json-schema\draft-03\schema` to valid `file:///C:/json-schema/draft-03/schema`
