### PR TITLE
Fix resolving two different schemas in Walker

### DIFF
--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -74,6 +74,14 @@ class Resolver
     }
 
     /**
+     * Clears internal schema resolution stack.
+     */
+    public function clearStack()
+    {
+        $this->stack = [];
+    }
+
+    /**
      * Returns the URI of the current schema.
      *
      * @return Uri


### PR DESCRIPTION
This is just a hotfix. Better solution is required to ensure that Resolver state stays valid even if `Walker::resolveReferences` throws an Exception
