### PR TITLE
Ignore unknown keywords during reference resolution

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,1 +1,0 @@
-approvals = 1

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,9 @@
 tools:
   external_code_coverage:
     timeout: 1200
+  php_cs_fixer:
+    config: { level: symfony }
+build_failure_conditions:
+  - 'issues.label("coding-style").exists'
+  - 'project.metric("scrutinizer.quality", < 9)'
+  - 'project.metric_change("scrutinizer.test_coverage", < 0)'

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,1 +1,0 @@
-Stéphane Klein <stephaneklein221@gmail.com> (@stefk)

--- a/bin/jval.php
+++ b/bin/jval.php
@@ -13,7 +13,7 @@ set_error_handler(function ($severity, $message, $file, $line) {
     throw new ErrorException($message, 0, $severity, $file, $line);
 });
 
-function writeln($msg, $type = null) {
+$writeln = function ($msg, $type = null) {
     switch ($type) {
         case 'info':
             $code = "\033[0;36m";
@@ -26,10 +26,10 @@ function writeln($msg, $type = null) {
     }
 
     echo "{$code}{$msg}\033[0m\n";
-}
+};
 
 if ($argc !== 3 && $argc !== 4) {
-    writeln('Usage: jval data_file schema_file [schema_uri]', 'info');
+    $writeln('Usage: jval data_file schema_file [schema_uri]', 'info');
     exit(1);
 }
 
@@ -39,7 +39,7 @@ $schemaUri = isset($argv[3]) ? $argv[3] : '';
 
 foreach ([$dataFile, $schemaFile] as $fileInfo) {
     if (!file_exists($fileInfo[1])) {
-        writeln("File \"{$fileInfo[0]}\" does not exist", 'error');
+        $writeln("File \"{$fileInfo[0]}\" does not exist", 'error');
         exit(1);
     }
 }
@@ -51,9 +51,9 @@ try {
     $errors = $validator->validate($instance, $schema, $schemaUri);
     echo json_encode($errors, JSON_PRETTY_PRINT) . "\n";
     ($count = count($errors)) > 0 ?
-        writeln("{$count} errors.", 'error') :
-        writeln('No error.', 'info');
+        $writeln("{$count} errors.", 'error') :
+        $writeln('No error.', 'info');
 } catch (Exception $ex) {
-    writeln($ex->getMessage(), 'error');
-    writeln($ex->getTraceAsString());
+    $writeln($ex->getMessage(), 'error');
+    $writeln($ex->getTraceAsString());
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -16,11 +16,6 @@ namespace JVal;
 class Context
 {
     /**
-     * @var string
-     */
-    private $version = Registry::VERSION_DRAFT_4;
-
-    /**
      * @var array
      */
     private $violations = [];
@@ -114,26 +109,6 @@ class Context
     public function countViolations()
     {
         return count($this->violations);
-    }
-
-    /**
-     * Returns the current schema version.
-     *
-     * @return string
-     */
-    public function getVersion()
-    {
-        return $this->version;
-    }
-
-    /**
-     * Sets the current schema version.
-     *
-     * @param string $version
-     */
-    public function setVersion($version)
-    {
-        $this->version = $version;
     }
 
     /**

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -56,7 +56,12 @@ class Registry
     /**
      * @var Constraint[][]
      */
-    private $constraintsForTypeCache;
+    private $constraintsForTypeCache = [];
+
+    /**
+     * @var array
+     */
+    private $keywordsCache = [];
 
     /**
      * Returns the constraints associated with a given JSON Schema version.
@@ -78,7 +83,7 @@ class Registry
 
     /**
      * Returns the constraints associated with a given JSON Schema version
-     * which supports given JSON type.
+     * supporting a given primitive type.
      *
      * @param string $version
      * @param string $type
@@ -105,13 +110,39 @@ class Registry
     }
 
     /**
+     * Returns whether a keyword is supported in a given JSON Schema version.
+     *
+     * @param string $version
+     * @param string $keyword
+     *
+     * @return bool
+     *
+     */
+    public function hasKeyword($version, $keyword)
+    {
+        $cache = & $this->keywordsCache[$version];
+
+        if ($cache === null) {
+            $cache = [];
+
+            foreach ($this->getConstraints($version) as $constraint) {
+                foreach ($constraint->keywords() as $constraintKeyword) {
+                    $cache[$constraintKeyword] = true;
+                }
+            }
+        }
+
+        return isset($cache[$keyword]);
+    }
+
+    /**
      * Loads the constraints associated with a given JSON Schema version.
      *
      * @param string $version
      *
      * @return Constraint[]
      *
-     * @throws \Exception if the version is not supported
+     * @throws UnsupportedVersionException if the version is not supported
      */
     protected function createConstraints($version)
     {

--- a/src/Testing/DataTestCase.php
+++ b/src/Testing/DataTestCase.php
@@ -97,4 +97,3 @@ abstract class DataTestCase extends BaseTestCase
      */
     abstract protected function getCaseFileNames();
 }
-

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -91,9 +91,9 @@ class Utils
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new JsonDecodeException(sprintf(
-               'Cannot decode JSON from file "%s" (error: %s)',
-               $filePath,
-               static::lastJsonErrorMessage()
+                'Cannot decode JSON from file "%s" (error: %s)',
+                $filePath,
+                static::lastJsonErrorMessage()
             ));
         }
 

--- a/src/Walker.php
+++ b/src/Walker.php
@@ -132,11 +132,7 @@ class Walker
             return $schema;
         }
 
-        if (isset($schema->{'$schema'})) {
-            $context->setVersion($schema->{'$schema'});
-        }
-
-        $version = $context->getVersion();
+        $version = $this->getVersion($schema);
         $constraints = $this->registry->getConstraints($version);
         $constraints = $this->filterConstraintsForSchema($constraints, $schema);
 
@@ -157,15 +153,11 @@ class Walker
      */
     public function applyConstraints($instance, stdClass $schema, Context $context)
     {
-        if (isset($schema->{'$schema'})) {
-            $context->setVersion($schema->{'$schema'});
-        }
-
         $cacheKey = gettype($instance).spl_object_hash($schema);
         $constraints = & $this->constraintsCache[$cacheKey];
 
         if ($constraints === null) {
-            $version = $context->getVersion();
+            $version = $this->getVersion($schema);
             $instanceType = Types::getPrimitiveTypeOf($instance);
             $constraints = $this->registry->getConstraintsForType($version, $instanceType);
             $constraints = $this->filterConstraintsForSchema($constraints, $schema);
@@ -197,6 +189,20 @@ class Walker
         $processed[$schemaHash] = true;
 
         return false;
+    }
+
+    /**
+     * Returns the version of a schema.
+     *
+     * @param stdClass $schema
+     *
+     * @return string
+     */
+    private function getVersion(stdClass $schema)
+    {
+        return property_exists($schema, '$schema') ?
+            $schema->{'$schema'} :
+            Registry::VERSION_CURRENT;
     }
 
     /**

--- a/src/Walker.php
+++ b/src/Walker.php
@@ -81,11 +81,12 @@ class Walker
      */
     private function doResolveReferences(stdClass $schema, Uri $uri)
     {
-        if ($this->isLooping($schema, $this->resolvedSchemas)) {
+        if ($this->isProcessed($schema, $this->resolvedSchemas)) {
             return $schema;
         }
 
         $inScope = false;
+
         if (property_exists($schema, 'id') && is_string($schema->id)) {
             $this->resolver->enter(new Uri($schema->id));
             $inScope = true;
@@ -127,7 +128,7 @@ class Walker
      */
     public function parseSchema(stdClass $schema, Context $context)
     {
-        if ($this->isLooping($schema, $this->parsedSchemas)) {
+        if ($this->isProcessed($schema, $this->parsedSchemas)) {
             return $schema;
         }
 
@@ -176,21 +177,25 @@ class Walker
     }
 
     /**
-     * Checks if given schema has been already visited.
+     * Returns whether a schema has already been processed and stored in
+     * a given collection. This is helpful both as a cache lookup and as
+     * an infinite recursion check.
      *
      * @param stdClass $schema
-     * @param array    $stack
+     * @param array    $processed
      *
      * @return bool
      */
-    private function isLooping(stdClass $schema, array &$stack)
+    private function isProcessed(stdClass $schema, array &$processed)
     {
         $schemaHash = spl_object_hash($schema);
-        if (isset($stack[$schemaHash])) {
+
+        if (isset($processed[$schemaHash])) {
             return true;
         }
 
-        $stack[$schemaHash] = true;
+        $processed[$schemaHash] = true;
+
         return false;
     }
 

--- a/tests/Data/issues/15-unknown-keywords-resolution.json
+++ b/tests/Data/issues/15-unknown-keywords-resolution.json
@@ -1,0 +1,17 @@
+{
+  "title": "issue #15: References under unknown keywords should be ignored",
+  "tests": [
+    {
+      "title": "$ref in unknown property",
+      "schema": {
+        "unknown": {
+          "$ref": "#/should/be/ignored"
+        }
+      },
+      "valid": [
+        {},
+        123
+      ]
+    }
+  ]
+}

--- a/tests/Issues/RegressionTest.php
+++ b/tests/Issues/RegressionTest.php
@@ -61,4 +61,3 @@ class RegressionTest extends DataTestCase
         return false;
     }
 }
-

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -19,4 +19,11 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         $registry = new Registry();
         $registry->getConstraints('unknown');
     }
+
+    public function testHasKeyword()
+    {
+        $registry = new Registry();
+        $this->assertFalse($registry->hasKeyword(Registry::VERSION_CURRENT, 'unknown'));
+        $this->assertTrue($registry->hasKeyword(Registry::VERSION_CURRENT, 'maximum'));
+    }
 }


### PR DESCRIPTION
Quick fix for #15. The only drawback is that references might still be resolved under keywords that don't allow sub-schemas. But in the current implementation, such schemas will produce errors during the parsing phase anyway.
