### PR TITLE
Avoid spl_object_hash for recursion checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.1"
+        "php": ">=5.4.1",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",
@@ -39,7 +40,7 @@
                 "name": "json-schema/test-suite",
                 "version": "dev-master",
                 "source": {
-                    "url": "https://github.com/json-schema/JSON-Schema-Test-Suite",
+                    "url": "https://github.com/json-schema-org/JSON-Schema-Test-Suite",
                     "type": "git",
                     "reference": "master"
                 }

--- a/src/Testing/BaseTestCase.php
+++ b/src/Testing/BaseTestCase.php
@@ -129,7 +129,7 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
             $reportParameters[4] = 'at least one error';
             $this->assertHasError($actualErrors, $reportParameters);
         } else {
-            $this->assertErrorsAreEqual($expectedErrors, $actualErrors, $reportParameters);
+            $this->assertErrorsAreEqual($actualErrors, $expectedErrors, $reportParameters);
         }
     }
 

--- a/src/Testing/DataTestCase.php
+++ b/src/Testing/DataTestCase.php
@@ -48,7 +48,7 @@ abstract class DataTestCase extends BaseTestCase
                             $caseFile,
                             "{$case->title} {$test->title}, valid instance #{$i}",
                             $instance,
-                            $test->schema,
+                            clone $test->schema,
                             true,
                             [],
                         ];

--- a/src/Walker.php
+++ b/src/Walker.php
@@ -180,8 +180,8 @@ class Walker
      * Returns whether a schema has already been processed and stored in
      * a given collection. This acts as an infinite recursion check.
      *
-     * @param stdClass $schema
-     * @param array    $processed
+     * @param stdClass          $schema
+     * @param SplObjectStorage  $storage
      *
      * @return bool
      */

--- a/src/Walker.php
+++ b/src/Walker.php
@@ -10,6 +10,7 @@
 namespace JVal;
 
 use stdClass;
+use SplObjectStorage;
 
 /**
  * Implements the three steps needed to perform a JSON Schema validation,
@@ -32,14 +33,14 @@ class Walker
     private $resolver;
 
     /**
-     * @var array
+     * @var SplObjectStorage
      */
-    private $parsedSchemas = [];
+    private $parsedSchemas;
 
     /**
-     * @var array
+     * @var SplObjectStorage
      */
-    private $resolvedSchemas = [];
+    private $resolvedSchemas;
 
     /**
      * @var Constraint[][]
@@ -56,6 +57,8 @@ class Walker
     {
         $this->registry = $registry;
         $this->resolver = $resolver;
+        $this->resolvedSchemas = new SplObjectStorage();
+        $this->parsedSchemas = new SplObjectStorage();
     }
 
     /**
@@ -175,23 +178,20 @@ class Walker
 
     /**
      * Returns whether a schema has already been processed and stored in
-     * a given collection. This is helpful both as a cache lookup and as
-     * an infinite recursion check.
+     * a given collection. This acts as an infinite recursion check.
      *
      * @param stdClass $schema
      * @param array    $processed
      *
      * @return bool
      */
-    private function isProcessed(stdClass $schema, array &$processed)
+    private function isProcessed(stdClass $schema, SplObjectStorage $storage)
     {
-        $schemaHash = spl_object_hash($schema);
-
-        if (isset($processed[$schemaHash])) {
+        if ($storage->contains($schema)) {
             return true;
         }
 
-        $processed[$schemaHash] = true;
+        $storage->attach($schema);
 
         return false;
     }

--- a/tests/Data/issues/17-unresolved-references.json
+++ b/tests/Data/issues/17-unresolved-references.json
@@ -1,0 +1,193 @@
+{
+  "title": "issue #13: missing errors due to unresolved references",
+  "tests": [
+    {
+      "title": "with nested references",
+      "schema": {
+        "oneOf": [
+          {
+            "$ref": "http://json-quiz.github.io/json-quiz/schemas/content/schema.json"
+          },
+          {
+            "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/choice/schema.json"
+          },
+          {
+            "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/match/schema.json"
+          },
+          {
+            "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/sort/schema.json"
+          },
+          {
+            "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/cloze/schema.json"
+          },
+          {
+            "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/short/schema.json"
+          }
+        ]
+      },
+      "valid": [
+        {
+          "id": "1",
+          "type": "text/plain",
+          "data": "Foo"
+        },
+        {
+          "id": "2",
+          "type": "application/x.cloze+json",
+          "title": "Question ?",
+          "text": "Lorem ipsum [[1]] sit amet."
+        }
+      ],
+      "invalid": [
+        {
+          "instance": {
+            "id": "2",
+            "items": [
+              {
+                "foo": "bar"
+              }
+            ]
+          },
+          "violations": [
+            {
+                "path": "",
+                "message": "property \"type\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"data\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"url\" is missing"
+            },
+            {
+                "path": "",
+                "message": "instance must match exactly one of the schemas listed in oneOf"
+            },
+            {
+                "path": "",
+                "message": "instance must match all the schemas listed in allOf"
+            },
+            {
+                "path": "",
+                "message": "property \"type\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"title\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"random\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"multiple\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"choices\" is missing"
+            },
+            {
+                "path": "",
+                "message": "instance must match all the schemas listed in allOf"
+            },
+            {
+                "path": "",
+                "message": "property \"type\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"title\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"firstSet\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"secondSet\" is missing"
+            },
+            {
+                "path": "",
+                "message": "instance must match all the schemas listed in allOf"
+            },
+            {
+                "path": "",
+                "message": "property \"type\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"title\" is missing"
+            },
+            {
+                "path": "/items/0",
+                "message": "property \"id\" is missing"
+            },
+            {
+                "path": "/items/0",
+                "message": "property \"type\" is missing"
+            },
+            {
+                "path": "/items/0",
+                "message": "property \"data\" is missing"
+            },
+            {
+                "path": "/items/0",
+                "message": "property \"url\" is missing"
+            },
+            {
+                "path": "/items/0",
+                "message": "instance must match exactly one of the schemas listed in oneOf"
+            },
+            {
+                "path": "/items/0",
+                "message": "instance must match all the schemas listed in allOf"
+            },
+            {
+                "path": "/items",
+                "message": "number of items should be greater than or equal to 2"
+            },
+            {
+                "path": "",
+                "message": "instance must match all the schemas listed in allOf"
+            },
+            {
+                "path": "",
+                "message": "property \"type\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"title\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"text\" is missing"
+            },
+            {
+                "path": "",
+                "message": "instance must match all the schemas listed in allOf"
+            },
+            {
+                "path": "",
+                "message": "property \"type\" is missing"
+            },
+            {
+                "path": "",
+                "message": "property \"title\" is missing"
+            },
+            {
+                "path": "",
+                "message": "instance must match all the schemas listed in allOf"
+            },
+            {
+                "path": "",
+                "message": "instance must match exactly one of the schemas listed in oneOf"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Data/schemas/valid/json-quiz/content/schema.json
+++ b/tests/Data/schemas/valid/json-quiz/content/schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "base": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$"
+        },
+        "meta": {
+          "$ref": "http://json-quiz.github.io/json-quiz/schemas/metadata/schema.json"
+        }
+      },
+      "required": ["id", "type"]
+    },
+    "embedded": {
+      "type": "object",
+      "properties": {
+        "encoding": {
+          "type": "string"
+        },
+        "data": {
+          "type": "string"
+        }
+      },
+      "required": ["data"]
+    },
+    "distant": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": ["url"]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "http://json-quiz.github.io/json-quiz/schemas/content/schema.json#/definitions/base"
+    },
+    {
+      "oneOf": [
+        {
+          "$ref": "http://json-quiz.github.io/json-quiz/schemas/content/schema.json#/definitions/embedded"
+        },
+        {
+          "$ref": "http://json-quiz.github.io/json-quiz/schemas/content/schema.json#/definitions/distant"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Data/schemas/valid/json-quiz/metadata/schema.json
+++ b/tests/Data/schemas/valid/json-quiz/metadata/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "authors": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "required": ["name"]
+      }
+    },
+    "license": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/Data/schemas/valid/json-quiz/question/base/schema.json
+++ b/tests/Data/schemas/valid/json-quiz/question/base/schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "pattern": "^application/x\\.[^/]+\\+json$"
+    },
+    "title": {
+      "type": "string"
+    },
+    "meta": {
+      "$ref": "http://json-quiz.github.io/json-quiz/schemas/metadata/schema.json"
+    },
+    "objects": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "http://json-quiz.github.io/json-quiz/schemas/content/schema.json"
+      }
+    },
+    "resources": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "http://json-quiz.github.io/json-quiz/schemas/content/schema.json"
+      }
+    },
+    "hints": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "penalty": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          }
+        },
+        "required": ["id", "text"],
+        "additionalProperties": false
+      }
+    },
+    "feedback": {
+      "type": "string"
+    },
+    "score": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": ["sum"]
+            }
+          },
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": ["fixed"]
+            },
+            "success": {
+              "type": "number"
+            },
+            "failure": {
+              "type": "number"
+            }
+          },
+          "required": ["type", "success", "failure"]
+        }
+      ]
+    }
+  },
+  "required": ["id", "type", "title"]
+}

--- a/tests/Data/schemas/valid/json-quiz/question/choice/schema.json
+++ b/tests/Data/schemas/valid/json-quiz/question/choice/schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [
+    {
+      "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/base/schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["application/x.choice+json"]
+        },
+        "random": {
+          "type": "boolean"
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "choices": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "http://json-quiz.github.io/json-quiz/schemas/content/schema.json"
+          }
+        },
+        "solutions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "score": {
+                "type": "number"
+              },
+              "feedback": {
+                "type": "string"
+              }
+            },
+            "required": ["id", "score"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["random", "multiple", "choices"]
+    }
+  ]
+}

--- a/tests/Data/schemas/valid/json-quiz/question/cloze/schema.json
+++ b/tests/Data/schemas/valid/json-quiz/question/cloze/schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [
+    {
+      "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/base/schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["application/x.cloze+json"]
+        },
+        "text": {
+          "type": "string"
+        },
+        "holes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "size": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "placeholder": {
+                "type": "string"
+              },
+              "choices": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["id"]
+          }
+        },
+        "solutions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "holeId": {
+                "type": "string"
+              },
+              "answers": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "text": {
+                      "type": "string"
+                    },
+                    "score": {
+                      "type": "number"
+                    }
+                  },
+                  "required": ["text", "score"]
+                }
+              }
+            },
+            "required": ["holeId", "answers"]
+          }
+        }
+      },
+      "required": ["text"]
+    }
+  ]
+}

--- a/tests/Data/schemas/valid/json-quiz/question/graphic/schema.json
+++ b/tests/Data/schemas/valid/json-quiz/question/graphic/schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions" : {
+    "coord": {
+      "type": "object",
+      "properties": {
+        "x": {"type" : "number"},
+        "y": {"type" : "number"}
+      },
+      "required": ["x", "y"]
+    },
+    "area":{
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "shape": {
+              "enum": ["circle"]
+            },
+            "center": {
+              "$ref": "#/definitions/coord"
+            },
+            "radius": {
+              "type": "number"
+            }
+          },
+          "required": ["id", "shape", "center", "radius"]
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "shape": {
+              "enum": ["rect"]
+            },
+            "coords": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/definitions/coord"
+              }
+            }
+          },
+          "required": ["id", "shape", "coords"]
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "shape": {
+              "enum": ["poly"]
+            },
+            "coords": {
+              "type": "array",
+              "minItems": 3,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/definitions/coord"
+              }
+            }
+          },
+          "required": ["id", "shape", "coords"]
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/base/schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "application/x.graphic+json"
+          ]
+        },
+        "image": {
+          "allOf": [
+            {
+              "$ref": "http://json-quiz.github.io/json-quiz/schemas/content/schema.json"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "width": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                }
+              },
+              "required": ["width", "height"]
+            }
+          ]
+        },
+        "pointers": {
+          "type": "number",
+          "minimum": 1
+        },
+        "solutions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "area": {
+                "$ref": "#/definitions/area"
+              },
+              "score": {
+                "type": "number"
+              },
+              "feedback": {
+                "type": "string"
+              }
+            },
+            "required": ["area", "score"]
+          }
+        }
+      },
+      "required": ["image", "pointers"]
+    }
+  ]
+}

--- a/tests/Data/schemas/valid/json-quiz/question/match/schema.json
+++ b/tests/Data/schemas/valid/json-quiz/question/match/schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [
+    {
+      "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/base/schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["application/x.match+json"]
+        },
+        "firstSet": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "http://json-quiz.github.io/json-quiz/schemas/content/schema.json"
+          }
+        },
+        "secondSet": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "http://json-quiz.github.io/json-quiz/schemas/content/schema.json"
+          }
+        },
+        "solutions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "firstId": {
+                "type": "string"
+              },
+              "secondId": {
+                "type": "string"
+              },
+              "score": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "firstId",
+              "secondId",
+              "score"
+            ]
+          }
+        }
+      },
+      "required": ["firstSet", "secondSet"]
+    }
+  ]
+}

--- a/tests/Data/schemas/valid/json-quiz/question/short/schema.json
+++ b/tests/Data/schemas/valid/json-quiz/question/short/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [
+    {
+      "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/base/schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["application/x.short+json"]
+        },
+        "solutions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "properties" : {
+              "score": {
+                "type": "number"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["score", "value"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/Data/schemas/valid/json-quiz/question/sort/schema.json
+++ b/tests/Data/schemas/valid/json-quiz/question/sort/schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [
+    {
+      "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/base/schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["application/x.sort+json"]
+        },
+        "items": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "http://json-quiz.github.io/json-quiz/schemas/content/schema.json"
+          }
+        },
+        "solution": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "itemId": {
+                "type": "string"
+              },
+              "score": {
+                "type": "number"
+              }
+            },
+            "required": ["itemId", "score"]
+          }
+        }
+      },
+      "required": ["items"]
+    }
+  ]
+}

--- a/tests/Data/schemas/valid/json-quiz/quiz/schema.json
+++ b/tests/Data/schemas/valid/json-quiz/quiz/schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "meta": {
+      "$ref": "http://json-quiz.github.io/json-quiz/schemas/metadata/schema.json"
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "http://json-quiz.github.io/json-quiz/schemas/content/schema.json"
+                },
+                {
+                  "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/choice/schema.json"
+                },
+                {
+                  "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/match/schema.json"
+                },
+                {
+                  "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/sort/schema.json"
+                },
+                {
+                  "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/cloze/schema.json"
+                },
+                {
+                  "$ref": "http://json-quiz.github.io/json-quiz/schemas/question/short/schema.json"
+                }
+              ]
+            }
+          }
+        },
+        "required": ["id", "items"]
+      }
+    }
+  },
+  "required": ["id", "steps"]
+}

--- a/tests/Issues/RegressionTest.php
+++ b/tests/Issues/RegressionTest.php
@@ -31,9 +31,15 @@ class RegressionTest extends DataTestCase
         $isInstanceValid,
         array $expectedErrors
     ) {
-        $validator = Validator::buildDefault();
+        $jsonQuizDir = realpath(__DIR__.'/../Data/schemas/valid/json-quiz');
+        $validator = Validator::buildDefault(function ($uri) use ($jsonQuizDir){
+            return str_replace(
+                'http://json-quiz.github.io/json-quiz/schemas',
+                'file://'.$jsonQuizDir,
+                $uri
+            );
+        });
         $actualErrors = $validator->validate($instance, $schema, $this->getLocalUri($file));
-
         $this->assertValidationResult(
             $file,
             $title,


### PR DESCRIPTION
Currently `spl_object_hash` is used for keeping track of already visited nodes when resolving/parsing a schema. However, the documented behaviour of this function is to reuse hashes of garbage collected objects. On large/nested schemas, collection cycles might happen in a middle of a resolution phase and destroy already visited nodes. The reattribution of previous hashes then messes up all the subsequent checks in a way that's hard to track. Using `SplObjectStorage` instances instead of arrays of hashes seems to be a reliable solution to this problem.
